### PR TITLE
Only use hostname when recording ES node stats

### DIFF
--- a/vor/elasticsearch.py
+++ b/vor/elasticsearch.py
@@ -137,7 +137,7 @@ class ElasticSearchNodeStatsGraphiteService(BaseElasticSearchGraphiteService):
 
     def flatten(self, data):
         for node in data['nodes'].itervalues():
-            name = node['name']
+            name = node['name'].split('.')[0]
             timestamp = node['timestamp']
 
             prefix = '%s.nodes.%s' % (self.prefix, name)


### PR DESCRIPTION
Discard domain from node name key,
otherwise graphite creates keys like `es.nodes.host.domain.com.metric`
