### PR TITLE
ES node stats - hostname only (optional + test)

### DIFF
--- a/vor/elasticsearch.py
+++ b/vor/elasticsearch.py
@@ -137,9 +137,16 @@ class ElasticSearchNodeStatsGraphiteService(BaseElasticSearchGraphiteService):
     suffixes = ('_in_bytes', '_in_millis')
     API = '_nodes/stats'
 
+    def __init__(self, *args, **kwargs):
+        self.hostname_only = kwargs.pop('hostname_only', False)
+        super(ElasticSearchNodeStatsGraphiteService, self).__init__(*args,
+                                                                    **kwargs)
+
     def flatten(self, data):
         for node in data['nodes'].itervalues():
-            name = node['name'].split('.')[0]
+            name = node['name']
+            if self.hostname_only:
+                name = name.split('.')[0]
             timestamp = node['timestamp']
 
             prefix = '%s.nodes.%s' % (self.prefix, name)

--- a/vor/elasticsearch.py
+++ b/vor/elasticsearch.py
@@ -139,8 +139,11 @@ class ElasticSearchNodeStatsGraphiteService(BaseElasticSearchGraphiteService):
 
     def __init__(self, *args, **kwargs):
         self.hostname_only = kwargs.pop('hostname_only', False)
-        super(ElasticSearchNodeStatsGraphiteService, self).__init__(*args,
-                                                                    **kwargs)
+        if type(self) != self.__class__:
+            # we're using an old version of Twisted that uses old style classes
+            BaseElasticSearchGraphiteService.__init__(self, *args, **kwargs)
+        else:
+            super(ElasticSearchNodeStatsGraphiteService, self).__init__(*args, **kwargs)
 
     def flatten(self, data):
         for node in data['nodes'].itervalues():

--- a/vor/elasticsearch.py
+++ b/vor/elasticsearch.py
@@ -139,7 +139,7 @@ class ElasticSearchNodeStatsGraphiteService(BaseElasticSearchGraphiteService):
 
     def flatten(self, data):
         for node in data['nodes'].itervalues():
-            name = node['name']
+            name = node['name'].split('.')[0]
             timestamp = node['timestamp']
 
             prefix = '%s.nodes.%s' % (self.prefix, name)


### PR DESCRIPTION
This is a follow up to #4.

> Very sorry for the late response. Can you write a test for this? Also, maybe make it an option to do hostname or fully qualified name?

The tests now cover this change, and I made it optional (existing behavior is preserved by default).

One change to note in the test data - before there was:

```
"name" : "es-data",
"hostname" : "es-data.example.org",
```

But when I curl `_nodes/stats`, I don't have a `"hostname"` key in ES version 1.4.2 or 2.2.0, and the value for `"name"` is the fully qualified name.
