### PR TITLE
Elasticsearch: ensure key is flattened before sending, including prefix.

### DIFF
--- a/vor/elasticsearch.py
+++ b/vor/elasticsearch.py
@@ -37,8 +37,8 @@ class BaseElasticSearchGraphiteService(service.Service):
 
 
     def _flattenValue(self, data, value, prefix, key, timestamp):
-        key = key.replace(' ', '')
-        flatKey = "%s.%s" % (prefix, key)
+        key = "%s.%s" % (prefix, key)
+        flatKey = key.replace(' ', '')
         if hasattr(value, 'upper'):
             return
         elif hasattr(value, 'iteritems'):


### PR DESCRIPTION
In production elasticsearch node names are generally set to be something useful like a hostname, but if you leave the defaults, they get silly names that can include spaces e.g. "Tagak the Leopard Lord".

In the BaseElasticSearchGraphiteService, these names are part of the prefix. This changes `_flattenValue` to replace spaces in both the prefix and the key before sending, instead of just the key.
