### PR TITLE
Support Elasticsearch with X-Pack Security

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,14 @@ python:
     - pypy
 
 env:
-    - TWISTED=svn+svn://svn.twistedmatrix.com/svn/Twisted/trunk
-    - TWISTED=Twisted==13.2.0
-    - TWISTED=Twisted==13.1.0
-    - TWISTED=Twisted==13.0.0
-    - TWISTED=Twisted==12.3.0
-    - TWISTED=Twisted==12.2.0
-    - TWISTED=Twisted==12.1.0
+    - TWISTED=https://github.com/twisted/twisted/archive/trunk.zip
+    - TWISTED=Twisted==16.0.0
+    - TWISTED=Twisted==17.9.0
 
 install:
-    - pip install pyflakes --use-mirrors
-    - pip install $TWISTED --use-mirrors
-    - pip install -r requirements.txt
+    - pip install pyflakes
+    - pip install -q $TWISTED
+    - pip install .
 
 script:
     - pyflakes vor

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,11 @@ setup(name='vor',
       ],
       zip_safe=False,
       install_requires=[
-          'Twisted >= 12.0.0',
+          'Twisted[tls] >= 16.0.0',
           'simplejson',
           'txredis',
           'pyyaml',
           'pybeanstalk',
+          'treq >= 16.12.0',
       ],
 )

--- a/vor/graphite.py
+++ b/vor/graphite.py
@@ -63,7 +63,7 @@ class GraphiteLineProtocol(LineReceiver):
         """
         Send a single metric.
         """
-        self.sendLine('%s %s %s' % (path, value, timestamp))
+        self.sendLine('%s %s %s' % (path.encode('utf-8'), value, timestamp))
 
 
 

--- a/vor/newsfragments/10.feature
+++ b/vor/newsfragments/10.feature
@@ -1,0 +1,1 @@
+vor.elasticsearch now supports basic authentication and (non-validated) https for its pollers.


### PR DESCRIPTION
This allows the poller to supply a username/password combination for
using basic authentication to an Elasticsearch node. For this it now
uses Treq instead of Twisted's built-in `getPage`. Additionally it (for
now) disables TLS certificate verification as the default certificate
tool doesn't provide proper hostnames in the certificate and the node is
usually addressed as `localhost`.